### PR TITLE
Ensure UIAlertView show on main thread.

### DIFF
--- a/JLPermissions/JLCalendarPermission.m
+++ b/JLPermissions/JLCalendarPermission.m
@@ -71,7 +71,9 @@
                                                      delegate:self
                                             cancelButtonTitle:cancelTitle
                                             otherButtonTitles:grantTitle, nil];
-      [alert show];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
     } break;
     case EKAuthorizationStatusRestricted:
     case EKAuthorizationStatusDenied: {

--- a/JLPermissions/JLCameraPermission.m
+++ b/JLPermissions/JLCameraPermission.m
@@ -84,7 +84,9 @@
                                                        delegate:self
                                               cancelButtonTitle:cancelTitle
                                               otherButtonTitles:grantTitle, nil];
-        [alert show];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
       } break;
     }
   } else {

--- a/JLPermissions/JLContactsPermission.m
+++ b/JLPermissions/JLContactsPermission.m
@@ -69,7 +69,9 @@
                                                      delegate:self
                                             cancelButtonTitle:cancelTitle
                                             otherButtonTitles:grantTitle, nil];
-      [alert show];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
     } break;
     case kABAuthorizationStatusRestricted:
     case kABAuthorizationStatusDenied: {

--- a/JLPermissions/JLFacebookPermission.m
+++ b/JLPermissions/JLFacebookPermission.m
@@ -83,7 +83,9 @@
                                                    delegate:self
                                           cancelButtonTitle:cancelTitle
                                           otherButtonTitles:grantTitle, nil];
-    [alert show];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [alert show];
+    });
   } else {
     _completion = completion;
     [self actuallyAuthorize];

--- a/JLPermissions/JLHealthPermission.m
+++ b/JLPermissions/JLHealthPermission.m
@@ -85,7 +85,9 @@
                                                        delegate:self
                                               cancelButtonTitle:cancelTitle
                                               otherButtonTitles:grantTitle, nil];
-        [alert show];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
       } break;
       case HKAuthorizationStatusSharingAuthorized: {
         if (completion) {

--- a/JLPermissions/JLLocationPermission.m
+++ b/JLPermissions/JLLocationPermission.m
@@ -77,7 +77,9 @@
                                                      delegate:self
                                             cancelButtonTitle:cancelTitle
                                             otherButtonTitles:grantTitle, nil];
-      [alert show];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
     } break;
     case kCLAuthorizationStatusDenied:
     case kCLAuthorizationStatusRestricted: {

--- a/JLPermissions/JLMicrophonePermission.m
+++ b/JLPermissions/JLMicrophonePermission.m
@@ -93,7 +93,9 @@
                                                        delegate:self
                                               cancelButtonTitle:cancelTitle
                                               otherButtonTitles:grantTitle, nil];
-        [alert show];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
       } break;
     }
   } else {

--- a/JLPermissions/JLNotificationPermission.m
+++ b/JLPermissions/JLNotificationPermission.m
@@ -88,7 +88,9 @@
                                                    delegate:self
                                           cancelButtonTitle:cancelTitle
                                           otherButtonTitles:grantTitle, nil];
-    [alert show];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [alert show];
+    });
   } else {
     if (completion) {
       completion(false, [self previouslyDeniedError]);
@@ -105,7 +107,9 @@
                                                  delegate:nil
                                         cancelButtonTitle:@"Ok"
                                         otherButtonTitles:nil];
-  [alert show];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [alert show];
+  });
 }
 
 - (void)unauthorize {

--- a/JLPermissions/JLPermissionsCore.m
+++ b/JLPermissions/JLPermissionsCore.m
@@ -99,7 +99,9 @@
                                                  delegate:nil
                                         cancelButtonTitle:@"Ok"
                                         otherButtonTitles:nil];
-  [alert show];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [alert show];
+  });
 }
 
 - (NSString *)permissionName {

--- a/JLPermissions/JLPhotosPermission.m
+++ b/JLPermissions/JLPhotosPermission.m
@@ -68,7 +68,9 @@
                                                      delegate:self
                                             cancelButtonTitle:cancelTitle
                                             otherButtonTitles:grantTitle, nil];
-      [alert show];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
     } break;
     case ALAuthorizationStatusRestricted:
     case ALAuthorizationStatusDenied: {

--- a/JLPermissions/JLRemindersPermission.m
+++ b/JLPermissions/JLRemindersPermission.m
@@ -72,7 +72,9 @@
                                                      delegate:self
                                             cancelButtonTitle:cancelTitle
                                             otherButtonTitles:grantTitle, nil];
-      [alert show];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
     } break;
     case EKAuthorizationStatusRestricted:
     case EKAuthorizationStatusDenied: {

--- a/JLPermissions/JLTwitterPermission.m
+++ b/JLPermissions/JLTwitterPermission.m
@@ -76,7 +76,9 @@
                                                    delegate:self
                                           cancelButtonTitle:cancelTitle
                                           otherButtonTitles:grantTitle, nil];
-    [alert show];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [alert show];
+    });
   } else {
     _completion = completion;
     [self actuallyAuthorize];


### PR DESCRIPTION
Recently I found a problem, if I check user permissions in the background thread, UIAlertView will not be displayed.

Although this is common sense, I think the library should do some appropriate precautions to prevent such problems(rather than let users to do this).