### PR TITLE
Fix for local notifications.

### DIFF
--- a/JLPermissions/JLNotificationPermission.h
+++ b/JLPermissions/JLNotificationPermission.h
@@ -86,4 +86,9 @@
  */
 - (NSString *)deviceID;
 
+
+
+// for local notifications, must be called from the app delegate
+-(void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+
 @end

--- a/JLPermissions/JLNotificationPermission.m
+++ b/JLPermissions/JLNotificationPermission.m
@@ -74,11 +74,13 @@
     notificationsOn = ([[UIApplication sharedApplication] enabledRemoteNotificationTypes] !=
                        UIRemoteNotificationTypeNone);
   }
-  if (existingID) {
+    
+    // I have disabled this because if you go into settings and turn off permissions for the app, the "cached" version (data from NSUserDefaults) is incorrect and not valid, therefore best to check permissions every time
+  /*if (existingID) {
     if (completion) {
       completion(existingID, nil);
     }
-  } else if (notificationsOn) {
+  } else*/ if (notificationsOn) {
     _completion = completion;
     [self actuallyAuthorize];
   } else if (!previouslyAsked) {
@@ -196,6 +198,30 @@
   }
 
   return exp;
+}
+
+
+// call this from the app delegate
+-(void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    if (notificationSettings.types != UIUserNotificationTypeNone)
+    {
+        [[NSUserDefaults standardUserDefaults] setObject:@"RandomSuccessTokenForLocalNotification" forKey:kJLDeviceToken];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        
+        if (_completion)
+        {
+            _completion(@"RandomSuccessTokenForLocalNotification", nil);
+        }
+    }
+    else
+    {
+        if (_completion)
+        {
+            NSError *error = [NSError errorWithDomain:@"System Denied" code:43 userInfo:nil];
+            _completion(nil, [self systemDeniedError:error]);
+        }
+    }
 }
 
 @end

--- a/JLPermissionsExample/JLAppDelegate.m
+++ b/JLPermissionsExample/JLAppDelegate.m
@@ -32,4 +32,11 @@
   [[JLNotificationPermission sharedInstance] notificationResult:nil error:error];
 }
 
+-(void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    NSLog(@"didRegisterUserNotificationSettings %@", notificationSettings);
+    
+    [[JLNotificationPermission sharedInstance] didRegisterUserNotificationSettings:notificationSettings];
+}
+
 @end


### PR DESCRIPTION
Code needs refactoring to fit the purpose of this library. I basically only needed local notifications to work. I've been lazy and just used the existing remote notification completion callback etc. This isn't ideal for a library like this, so feel free to rewrite this as required.

I've also commented out a bit of code that caused issues in my testing. The user always has the possibility to turn off notifications inside the OS settings after the user already has authorised permissions in-app. The stored value from NSUserDefaults therefore returned is invalid. The commented code forces it to check every time with the system. You'll see what I mean when you look at the code, it should make sense.