### PR TITLE
Fix does not register remote notifications every time.

### DIFF
--- a/JLPermissions/JLNotificationPermission.m
+++ b/JLPermissions/JLNotificationPermission.m
@@ -74,11 +74,7 @@
     notificationsOn = ([[UIApplication sharedApplication] enabledRemoteNotificationTypes] !=
                        UIRemoteNotificationTypeNone);
   }
-  if (existingID) {
-    if (completion) {
-      completion(existingID, nil);
-    }
-  } else if (notificationsOn) {
+  if (notificationsOn) {
     _completion = completion;
     [self actuallyAuthorize];
   } else if (!previouslyAsked) {


### PR DESCRIPTION
I use this library in my app, recently, I found a lot of push notifications sent successfully, but the user did not receive.

I eventually found the library cache device token, and no longer register push notification if it detects the cache, which is wrong approach, because the device token will change, and if we do not register every time user launch applications, system-related notification delegate methods will not be called, we can not update the latest device token, the user will not receive push notifications.