### PR TITLE
Fixed a bug where permissions were not checked properly for Notifications

### DIFF
--- a/JLPermissions/JLNotificationPermission.m
+++ b/JLPermissions/JLNotificationPermission.m
@@ -30,16 +30,30 @@
 #pragma mark - Notifications
 
 - (JLAuthorizationStatus)authorizationStatus {
-  BOOL previouslyAsked =
-      [[NSUserDefaults standardUserDefaults] boolForKey:kJLAskedForNotificationPermission];
-  NSString *token = [[NSUserDefaults standardUserDefaults] objectForKey:kJLDeviceToken];
-  if (token) {
-    return JLPermissionAuthorized;
-  } else if (previouslyAsked) {
-    return JLPermissionDenied;
-  } else {
-    return JLPermissionNotDetermined;
-  }
+    BOOL notificationsOn = NO;
+    if ([[UIApplication sharedApplication]
+         respondsToSelector:@selector(currentUserNotificationSettings)]) {
+        notificationsOn = ([[UIApplication sharedApplication] currentUserNotificationSettings].types !=
+                           UIUserNotificationTypeNone);
+    } else {
+        notificationsOn = ([[UIApplication sharedApplication] enabledRemoteNotificationTypes] !=
+                           UIRemoteNotificationTypeNone);
+    }
+    if (notificationsOn) {
+        return JLPermissionAuthorized;
+    }
+    else {
+      BOOL previouslyAsked =
+          [[NSUserDefaults standardUserDefaults] boolForKey:kJLAskedForNotificationPermission];
+      NSString *token = [[NSUserDefaults standardUserDefaults] objectForKey:kJLDeviceToken];
+      if (token) {
+        return JLPermissionAuthorized;
+      } else if (previouslyAsked) {
+        return JLPermissionDenied;
+      } else {
+        return JLPermissionNotDetermined;
+      }
+    }
 }
 
 - (void)authorize:(NotificationAuthorizationHandler)completion {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,7 +11,7 @@ DEPENDENCIES:
   - DBPrivacyHelper (= 0.6.1)
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
-  DBPrivacyHelper: fc1f3872df4027bf22bf29eccd7825c061289941
+  CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
+  DBPrivacyHelper: 51c2aabbd3717e51e16b99950d04a16a0471792a
 
-COCOAPODS: 0.35.0
+COCOAPODS: 0.37.2


### PR DESCRIPTION
Notifications were not checked against the system API. Instead, they were only being checked against what the library stored in NSUserDefaults, rendering the result unreliable most of the time.

This commit fixes that issue.