### PR TITLE
Add new flag to allow user decide whether to show the extra alert view.

### DIFF
--- a/JLPermissions/JLCalendarPermission.m
+++ b/JLPermissions/JLCalendarPermission.m
@@ -66,14 +66,18 @@
     } break;
     case EKAuthorizationStatusNotDetermined: {
       _completion = completion;
-      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:cancelTitle
-                                            otherButtonTitles:grantTitle, nil];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [alert show];
-      });
+      if (self.isExtraAlertEnabled) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                        message:message
+                                                       delegate:self
+                                              cancelButtonTitle:cancelTitle
+                                              otherButtonTitles:grantTitle, nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
+      } else {
+        [self actuallyAuthorize];
+      }
     } break;
     case EKAuthorizationStatusRestricted:
     case EKAuthorizationStatusDenied: {

--- a/JLPermissions/JLCameraPermission.m
+++ b/JLPermissions/JLCameraPermission.m
@@ -79,14 +79,18 @@
       } break;
       case AVAuthorizationStatusNotDetermined: {
         _completion = completion;
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                        message:message
-                                                       delegate:self
-                                              cancelButtonTitle:cancelTitle
-                                              otherButtonTitles:grantTitle, nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [alert show];
-        });
+        if (self.isExtraAlertEnabled) {
+          UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                          message:message
+                                                         delegate:self
+                                                cancelButtonTitle:cancelTitle
+                                                otherButtonTitles:grantTitle, nil];
+          dispatch_async(dispatch_get_main_queue(), ^{
+            [alert show];
+          });
+        } else {
+          [self actuallyAuthorize];
+        }
       } break;
     }
   } else {

--- a/JLPermissions/JLContactsPermission.m
+++ b/JLPermissions/JLContactsPermission.m
@@ -64,14 +64,18 @@
     } break;
     case kABAuthorizationStatusNotDetermined: {
       _completion = completion;
-      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:cancelTitle
-                                            otherButtonTitles:grantTitle, nil];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [alert show];
-      });
+      if (self.isExtraAlertEnabled) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                        message:message
+                                                       delegate:self
+                                              cancelButtonTitle:cancelTitle
+                                              otherButtonTitles:grantTitle, nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
+      } else {
+        [self actuallyAuthorize];
+      }
     } break;
     case kABAuthorizationStatusRestricted:
     case kABAuthorizationStatusDenied: {

--- a/JLPermissions/JLFacebookPermission.m
+++ b/JLPermissions/JLFacebookPermission.m
@@ -78,14 +78,18 @@
     }
   } else if (!previouslyAsked) {
     _completion = completion;
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                    message:message
-                                                   delegate:self
-                                          cancelButtonTitle:cancelTitle
-                                          otherButtonTitles:grantTitle, nil];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [alert show];
-    });
+    if (self.isExtraAlertEnabled) {
+      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                      message:message
+                                                     delegate:self
+                                            cancelButtonTitle:cancelTitle
+                                            otherButtonTitles:grantTitle, nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
+    } else {
+      [self actuallyAuthorize];
+    }
   } else {
     _completion = completion;
     [self actuallyAuthorize];

--- a/JLPermissions/JLHealthPermission.m
+++ b/JLPermissions/JLHealthPermission.m
@@ -80,14 +80,18 @@
     switch (status) {
       case HKAuthorizationStatusNotDetermined: {
         _completion = completion;
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                        message:message
-                                                       delegate:self
-                                              cancelButtonTitle:cancelTitle
-                                              otherButtonTitles:grantTitle, nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [alert show];
-        });
+        if (self.isExtraAlertEnabled) {
+          UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                          message:message
+                                                         delegate:self
+                                                cancelButtonTitle:cancelTitle
+                                                otherButtonTitles:grantTitle, nil];
+          dispatch_async(dispatch_get_main_queue(), ^{
+            [alert show];
+          });
+        } else {
+          [self actuallyAuthorize];
+        }
       } break;
       case HKAuthorizationStatusSharingAuthorized: {
         if (completion) {

--- a/JLPermissions/JLLocationPermission.m
+++ b/JLPermissions/JLLocationPermission.m
@@ -72,14 +72,18 @@
     } break;
     case kCLAuthorizationStatusNotDetermined: {
       _completion = completion;
-      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:cancelTitle
-                                            otherButtonTitles:grantTitle, nil];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [alert show];
-      });
+      if (self.isExtraAlertEnabled) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                        message:message
+                                                       delegate:self
+                                              cancelButtonTitle:cancelTitle
+                                              otherButtonTitles:grantTitle, nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
+      } else {
+        [self actuallyAuthorize];
+      }
     } break;
     case kCLAuthorizationStatusDenied:
     case kCLAuthorizationStatusRestricted: {

--- a/JLPermissions/JLMicrophonePermission.m
+++ b/JLPermissions/JLMicrophonePermission.m
@@ -90,14 +90,18 @@
       } break;
       case AVAudioSessionRecordPermissionUndetermined: {
         _completion = completion;
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                        message:message
-                                                       delegate:self
-                                              cancelButtonTitle:cancelTitle
-                                              otherButtonTitles:grantTitle, nil];
-        dispatch_async(dispatch_get_main_queue(), ^{
-          [alert show];
-        });
+        if (self.isExtraAlertEnabled) {
+          UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                          message:message
+                                                         delegate:self
+                                                cancelButtonTitle:cancelTitle
+                                                otherButtonTitles:grantTitle, nil];
+          dispatch_async(dispatch_get_main_queue(), ^{
+            [alert show];
+          });
+        } else {
+          [self actuallyAuthorize];
+        }
       } break;
     }
   } else {

--- a/JLPermissions/JLNotificationPermission.m
+++ b/JLPermissions/JLNotificationPermission.m
@@ -77,14 +77,18 @@
     [self actuallyAuthorize];
   } else if (!previouslyAsked) {
     _completion = completion;
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                    message:message
-                                                   delegate:self
-                                          cancelButtonTitle:cancelTitle
-                                          otherButtonTitles:grantTitle, nil];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [alert show];
-    });
+    if (self.isExtraAlertEnabled) {
+      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                      message:message
+                                                     delegate:self
+                                            cancelButtonTitle:cancelTitle
+                                            otherButtonTitles:grantTitle, nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
+    } else {
+      [self actuallyAuthorize];
+    }
   } else {
     if (completion) {
       completion(false, [self previouslyDeniedError]);

--- a/JLPermissions/JLPermissionsCore.h
+++ b/JLPermissions/JLPermissionsCore.h
@@ -41,6 +41,12 @@ typedef void (^NotificationAuthorizationHandler)(NSString *__nullable deviceID,
 @interface JLPermissionsCore : NSObject<UIAlertViewDelegate>
 
 /**
+ * A Boolean property that indicates whether the extra alert view will be shown 
+ * before the library actually requests permissions to the system.
+ */
+@property(nonatomic, getter=isExtraAlertEnabled) BOOL extraAlertEnabled;
+
+/**
  * @return whether or not user has granted access to the calendar
  */
 - (JLAuthorizationStatus)authorizationStatus;

--- a/JLPermissions/JLPermissionsCore.m
+++ b/JLPermissions/JLPermissionsCore.m
@@ -11,6 +11,14 @@
 
 @implementation JLPermissionsCore
 
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [self setExtraAlertEnabled:YES];
+  }
+  return self;
+}
+
 - (NSString *)defaultTitle:(NSString *)authorizationType {
   return [NSString
       stringWithFormat:@"\"%@\" Would Like to Access Your %@", [self appName], authorizationType];

--- a/JLPermissions/JLPhotosPermission.m
+++ b/JLPermissions/JLPhotosPermission.m
@@ -63,14 +63,18 @@
       break;
     case ALAuthorizationStatusNotDetermined: {
       _completion = completion;
-      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:cancelTitle
-                                            otherButtonTitles:grantTitle, nil];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [alert show];
-      });
+      if (self.isExtraAlertEnabled) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                        message:message
+                                                       delegate:self
+                                              cancelButtonTitle:cancelTitle
+                                              otherButtonTitles:grantTitle, nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
+      } else {
+        [self actuallyAuthorize];
+      }
     } break;
     case ALAuthorizationStatusRestricted:
     case ALAuthorizationStatusDenied: {

--- a/JLPermissions/JLRemindersPermission.m
+++ b/JLPermissions/JLRemindersPermission.m
@@ -67,14 +67,18 @@
     } break;
     case EKAuthorizationStatusNotDetermined: {
       _completion = completion;
-      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                      message:message
-                                                     delegate:self
-                                            cancelButtonTitle:cancelTitle
-                                            otherButtonTitles:grantTitle, nil];
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [alert show];
-      });
+      if (self.isExtraAlertEnabled) {
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                        message:message
+                                                       delegate:self
+                                              cancelButtonTitle:cancelTitle
+                                              otherButtonTitles:grantTitle, nil];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [alert show];
+        });
+      } else {
+        [self actuallyAuthorize];
+      }
     } break;
     case EKAuthorizationStatusRestricted:
     case EKAuthorizationStatusDenied: {

--- a/JLPermissions/JLTwitterPermission.m
+++ b/JLPermissions/JLTwitterPermission.m
@@ -71,14 +71,18 @@
     }
   } else if (!previouslyAsked) {
     _completion = completion;
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
-                                                    message:message
-                                                   delegate:self
-                                          cancelButtonTitle:cancelTitle
-                                          otherButtonTitles:grantTitle, nil];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [alert show];
-    });
+    if (self.isExtraAlertEnabled) {
+      UIAlertView *alert = [[UIAlertView alloc] initWithTitle:messageTitle
+                                                      message:message
+                                                     delegate:self
+                                            cancelButtonTitle:cancelTitle
+                                            otherButtonTitles:grantTitle, nil];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [alert show];
+      });
+    } else {
+      [self actuallyAuthorize];
+    }
   } else {
     _completion = completion;
     [self actuallyAuthorize];

--- a/JLPermissionsExample/Base.lproj/Main.storyboard
+++ b/JLPermissionsExample/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9058" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9048"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -215,6 +215,17 @@
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zkc-0U-GEH">
+                                <rect key="frame" x="527" y="544" width="51" height="31"/>
+                                <animations/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Extra Alert" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mxi-Ue-nKd">
+                                <rect key="frame" x="389" y="551" width="108" height="17"/>
+                                <animations/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -257,6 +268,7 @@
                             <constraint firstItem="jyE-G4-BxP" firstAttribute="top" secondItem="8QF-uB-iEX" secondAttribute="bottom" constant="8" symbolic="YES" id="Q2u-Gq-zay"/>
                             <constraint firstItem="71b-ad-k9L" firstAttribute="top" secondItem="ALj-NS-dkY" secondAttribute="bottom" constant="8" symbolic="YES" id="QmM-Il-Aeg"/>
                             <constraint firstItem="Jd7-n6-0zH" firstAttribute="leading" secondItem="DHA-YI-8g9" secondAttribute="leading" id="SH4-jd-9mf"/>
+                            <constraint firstItem="Zkc-0U-GEH" firstAttribute="leading" secondItem="mxi-Ue-nKd" secondAttribute="trailing" constant="30" id="TUr-cT-MRY"/>
                             <constraint firstItem="REb-yi-ChP" firstAttribute="top" secondItem="1I5-uj-hmR" secondAttribute="bottom" constant="8" symbolic="YES" id="TV3-CY-7tG"/>
                             <constraint firstItem="lYS-Cp-esb" firstAttribute="leading" secondItem="wEa-Xk-gx6" secondAttribute="leading" id="Vb4-mr-3FB"/>
                             <constraint firstItem="wEa-Xk-gx6" firstAttribute="trailing" secondItem="c1x-uv-kni" secondAttribute="trailing" id="WBj-zc-Sky"/>
@@ -271,6 +283,7 @@
                             <constraint firstItem="REb-yi-ChP" firstAttribute="top" secondItem="n3k-C5-vbj" secondAttribute="top" id="eS7-bn-JxO"/>
                             <constraint firstItem="c1x-uv-kni" firstAttribute="top" secondItem="K10-SD-DWI" secondAttribute="bottom" constant="8" symbolic="YES" id="fSb-yf-yM9"/>
                             <constraint firstItem="Jd7-n6-0zH" firstAttribute="top" secondItem="lte-G4-3J6" secondAttribute="top" id="fmu-wK-PoU"/>
+                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="Zkc-0U-GEH" secondAttribute="bottom" constant="25" id="gEc-Vl-QGT"/>
                             <constraint firstItem="7e3-kO-tH2" firstAttribute="top" secondItem="t5z-ft-gUz" secondAttribute="bottom" constant="8" symbolic="YES" id="gJi-Kf-kvR"/>
                             <constraint firstItem="Jd7-n6-0zH" firstAttribute="top" secondItem="DHA-YI-8g9" secondAttribute="bottom" constant="8" symbolic="YES" id="hAw-oZ-nO2"/>
                             <constraint firstItem="LxU-zO-ifI" firstAttribute="trailing" secondItem="71b-ad-k9L" secondAttribute="trailing" id="hLM-VK-C7w"/>
@@ -283,11 +296,13 @@
                             <constraint firstItem="REb-yi-ChP" firstAttribute="trailing" secondItem="ALj-NS-dkY" secondAttribute="trailing" id="lxR-hW-XQ7"/>
                             <constraint firstItem="lYS-Cp-esb" firstAttribute="leading" secondItem="lte-G4-3J6" secondAttribute="leading" id="mPc-ls-De4"/>
                             <constraint firstItem="axU-mH-rbG" firstAttribute="trailing" secondItem="oxC-5s-ZVD" secondAttribute="trailing" id="nx4-a3-86r"/>
+                            <constraint firstItem="Zkc-0U-GEH" firstAttribute="centerY" secondItem="mxi-Ue-nKd" secondAttribute="centerY" id="nxt-v6-wwb"/>
                             <constraint firstItem="lYS-Cp-esb" firstAttribute="top" secondItem="wEa-Xk-gx6" secondAttribute="bottom" constant="8" symbolic="YES" id="oFR-Kj-Ult"/>
                             <constraint firstItem="ALj-NS-dkY" firstAttribute="leading" secondItem="71b-ad-k9L" secondAttribute="leading" id="oJc-BG-xgF"/>
                             <constraint firstItem="DHA-YI-8g9" firstAttribute="top" secondItem="lYS-Cp-esb" secondAttribute="top" id="oo5-IV-GZq"/>
                             <constraint firstItem="1I5-uj-hmR" firstAttribute="trailing" secondItem="ORe-AI-GdR" secondAttribute="trailing" id="pTy-2t-leS"/>
                             <constraint firstItem="LxU-zO-ifI" firstAttribute="top" secondItem="wEa-Xk-gx6" secondAttribute="top" id="psx-hS-ceM"/>
+                            <constraint firstAttribute="trailing" secondItem="Zkc-0U-GEH" secondAttribute="trailing" constant="24" id="q89-iL-Gx9"/>
                             <constraint firstItem="DHA-YI-8g9" firstAttribute="top" secondItem="LxU-zO-ifI" secondAttribute="bottom" constant="8" symbolic="YES" id="qRX-nt-s84"/>
                             <constraint firstItem="ORe-AI-GdR" firstAttribute="top" secondItem="axU-mH-rbG" secondAttribute="bottom" constant="8" symbolic="YES" id="qxO-sI-F0N"/>
                             <constraint firstItem="1I5-uj-hmR" firstAttribute="leading" secondItem="ORe-AI-GdR" secondAttribute="leading" id="rMt-CS-LCI"/>
@@ -308,6 +323,7 @@
                         <outlet property="photoLibraryLabel" destination="axU-mH-rbG" id="px2-TM-0dB"/>
                         <outlet property="pushNotificationLabel" destination="REb-yi-ChP" id="UaP-D6-gTR"/>
                         <outlet property="remindersLabel" destination="ORe-AI-GdR" id="vsv-qn-zkE"/>
+                        <outlet property="showExtraAlertSwitch" destination="Zkc-0U-GEH" id="vcS-0y-ltD"/>
                         <outlet property="twitterLabel" destination="ALj-NS-dkY" id="cg1-6N-uqS"/>
                     </connections>
                 </viewController>

--- a/JLPermissionsExample/JLViewController.m
+++ b/JLPermissionsExample/JLViewController.m
@@ -34,6 +34,8 @@
 @property(strong, nonatomic) IBOutlet UILabel *healthLabel;
 @property(strong, nonatomic) IBOutlet UILabel *cameraLabel;
 
+@property(strong, nonatomic) IBOutlet UISwitch *showExtraAlertSwitch;
+
 @end
 
 @implementation JLViewController
@@ -87,6 +89,7 @@
 }
 
 - (IBAction)pushNotifications:(id)sender {
+  [[JLNotificationPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLNotificationPermission sharedInstance] authorize:^(NSString *deviceID, NSError *error) {
     NSLog(@"pushNotifications returned %@ with error %@", deviceID, error);
     [self updateStatusLabels];
@@ -94,6 +97,7 @@
 }
 
 - (IBAction)contacts:(id)sender {
+  [[JLContactsPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLContactsPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"contacts returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLContactsPermission sharedInstance]
@@ -104,6 +108,7 @@
 }
 
 - (IBAction)photoLibrary:(id)sender {
+  [[JLPhotosPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLPhotosPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"photoLibrary returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLPhotosPermission sharedInstance] granted:granted error:error];
@@ -112,6 +117,7 @@
 }
 
 - (IBAction)calendar:(id)sender {
+  [[JLCalendarPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLCalendarPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"calendar returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLCalendarPermission sharedInstance]
@@ -122,6 +128,7 @@
 }
 
 - (IBAction)reminders:(id)sender {
+  [[JLRemindersPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLRemindersPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"reminders returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLRemindersPermission sharedInstance]
@@ -132,6 +139,7 @@
 }
 
 - (IBAction)microphone:(id)sender {
+  [[JLMicrophonePermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLMicrophonePermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"microphone returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLMicrophonePermission sharedInstance]
@@ -142,6 +150,7 @@
 }
 
 - (IBAction)health:(id)sender {
+  [[JLHealthPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLHealthPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"health returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLHealthPermission sharedInstance] granted:granted error:error];
@@ -150,6 +159,7 @@
 }
 
 - (IBAction)locations:(id)sender {
+  [[JLLocationPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLLocationPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"locations returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLLocationPermission sharedInstance]
@@ -160,6 +170,7 @@
 }
 
 - (IBAction)twitter:(id)sender {
+  [[JLTwitterPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLTwitterPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"twitter returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLTwitterPermission sharedInstance]
@@ -170,6 +181,7 @@
 }
 
 - (IBAction)facebook:(id)sender {
+  [[JLFacebookPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLFacebookPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"facebook returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLFacebookPermission sharedInstance]
@@ -180,6 +192,7 @@
 }
 
 - (IBAction)camera:(id)sender {
+  [[JLCameraPermission sharedInstance] setExtraAlertEnabled:self.showExtraAlertSwitch.on];
   [[JLCameraPermission sharedInstance] authorize:^(bool granted, NSError *error) {
     NSLog(@"camera returned %@ with error %@", @(granted), error);
     [self presentReenableVCForCore:[JLCameraPermission sharedInstance] granted:granted error:error];


### PR DESCRIPTION
- Added the following flag to `JLPermissionsCore` and update related methods in the rests.
- The value is initialized to `YES`
```objc
/**
 * A Boolean property that indicates whether the extra alert view will be shown 
 * before the library actually requests permissions to the system.
 */
@property(nonatomic, getter=isExtraAlertEnabled) BOOL extraAlertEnabled;
```