### PR TITLE
Make authorization fail if location services is disabled.

### DIFF
--- a/JLPermissions/JLLocationPermission.m
+++ b/JLPermissions/JLLocationPermission.m
@@ -64,7 +64,10 @@
                 completion:(AuthorizationHandler)completion {
   if (![CLLocationManager locationServicesEnabled]) {
     if (completion) {
-      completion(false, [self previouslyDeniedError]);
+      NSError *error = [NSError errorWithDomain:@"SystemDenied"
+                                           code:JLPermissionSystemDenied
+                                       userInfo:@{NSLocalizedDescriptionKey: @"System location services are disabled"}];
+      completion(false, error);
     }
     return;
   }

--- a/JLPermissions/JLLocationPermission.m
+++ b/JLPermissions/JLLocationPermission.m
@@ -62,6 +62,13 @@
                cancelTitle:(NSString *)cancelTitle
                 grantTitle:(NSString *)grantTitle
                 completion:(AuthorizationHandler)completion {
+  if (![CLLocationManager locationServicesEnabled]) {
+    if (completion) {
+      completion(false, [self previouslyDeniedError]);
+    }
+    return;
+  }
+  
   CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
   switch (authorizationStatus) {
     case kCLAuthorizationStatusAuthorizedAlways:


### PR DESCRIPTION
Steps to reproduce:
1. Enable location services, ask user for location permission, and gained.
2. Disable location services, restart app, ask user for location permission, still gained, but failed to get the location data.

Should we do this? I don't know if we can conflate the location services enabled and authorized state .